### PR TITLE
Stop the daemon if we're not configured for it

### DIFF
--- a/bin/run-daemon
+++ b/bin/run-daemon
@@ -4,4 +4,5 @@ set -x
 
 if grep -q snap_core= /proc/cmdline || [ "$(snapctl get daemon)" = "true" ]
 then exec "$@"
+else snapctl stop $SNAP_NAME.daemon
 fi


### PR DESCRIPTION
Stop the daemon if we're not configured for it.

This makes it possible for derived snaps to use `restart-condition:` sensibly