### PR TITLE
Don't try to create the `$XDG_RUNTIME_DIR` directory until the parent directory is known to exist

### DIFF
--- a/bin/wayland-launch
+++ b/bin/wayland-launch
@@ -2,15 +2,10 @@
 
 set -x
 
-mkdir -p "$XDG_RUNTIME_DIR" -m 700
-
-if [ -z "${WAYLAND_DISPLAY}" ]
-then WAYLAND_DISPLAY=wayland-0
-fi
-
-real_wayland=$(dirname "$XDG_RUNTIME_DIR")/${WAYLAND_DISPLAY}
+real_wayland=$(dirname "$XDG_RUNTIME_DIR")/${WAYLAND_DISPLAY:-wayland-0}
 while [ ! -O "${real_wayland}" ]; do echo waiting for Wayland socket; sleep 4; done
 
+mkdir -p "$XDG_RUNTIME_DIR" -m 700
 ln -sf "${real_wayland}" "$XDG_RUNTIME_DIR"
 unset DISPLAY
 


### PR DESCRIPTION
Don't try to create the `$XDG_RUNTIME_DIR` directory until the parent directory is known to exist. (Fixes: #5)