### PR TITLE
Better handling of interfaces (mostly Wayland on Core)

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
 set -e
 
-for PLUG in %PLUGS%; do sudo snap connect %SNAP%:${PLUG}; done
+snap_connect() {
+  available_providers="$(snap interface $2 | sed -e '1,/slots:/d')"
+  for PROVIDER in snapd ubuntu-frame mir-kiosk; do
+     if echo "$available_providers" | grep --quiet "\- ${PROVIDER}"; then
+       sudo snap connect "$1:$2" "${PROVIDER}:$2"
+       return 0
+     fi
+  done
+  echo "Warning: Failed to connect '$2'. Please connect manually, available providers are:\n$available_providers"
+}
+
+for PLUG in %PLUGS%; do snap_connect %SNAP% ${PLUG}; done

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,6 +2,10 @@
 set -e
 
 snap_connect() {
+  if snap connections | grep --quiet "$1:$2"; then
+    return 0
+  fi
+
   available_providers="$(snap interface $2 | sed -e '1,/slots:/d')"
   for PROVIDER in snapd ubuntu-frame mir-kiosk; do
      if echo "$available_providers" | grep --quiet "\- ${PROVIDER}"; then

--- a/bin/wayland-launch
+++ b/bin/wayland-launch
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -e
-set -x
 
 for PLUG in %PLUGS%; do
   if ! snapctl is-connected ${PLUG}
   then
-    echo "${PLUG} interface not connected! Please run: /snap/%SNAP%/current/bin/setup.sh"
-    exit 1
+    echo "WARNING: ${PLUG} interface not connected! Please run: /snap/%SNAP%/current/bin/setup.sh"
   fi
 done
 


### PR DESCRIPTION
On Ubuntu Core there's no system "wayland" plug, so we also check for ubuntu-frame and mir-kiosk.

And erroring is too drastic for interfaces that might not be needed: a WARNING is enough.

Finally there's too much spam in the logs.