### PR TITLE
Make setup.sh more likely to work

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -19,5 +19,5 @@ snap_connect_harder() {
 }
 
 for PLUG in %PLUGS%; do
-  sudo snap connect "%SNAP%:${PLUG}" || snap_connect_harder ${PLUG}
+  sudo snap connect "%SNAP%:${PLUG}" 2> /dev/null || snap_connect_harder ${PLUG}
 done

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,4 +1,30 @@
 #!/bin/sh
 set -e
 
-for PLUG in %PLUGS%; do sudo snap connect %SNAP%:${PLUG}; done
+snap_connect() {
+  if snap connections | grep --quiet "[[:space:]]:$2"; then
+    # Where there's a system slot use it
+    sudo snap connect "$1:$2"
+  else
+    # Otherwise note the available slot providers
+    available_providers="$(snap interface "$2" | sed -e '1,/slots:/d')"
+
+    # For wayland try some well known providers
+    if [ "wayland" = "$2" ]; then
+      for PROVIDER in ubuntu-frame mir-kiosk; do
+         if echo "$available_providers" | grep --quiet "\- ${PROVIDER}"; then
+           sudo snap connect "$1:$2" "${PROVIDER}:$2"
+           return 0
+         fi
+      done
+    fi
+
+    echo "Warning: Failed to connect '$2'. Please connect manually, available providers are:\n$available_providers"
+  fi
+}
+
+for PLUG in %PLUGS%; do
+  if ! snap connections | grep --quiet "%SNAP%:${PLUG}"; then
+    snap_connect %SNAP% ${PLUG}
+  fi
+done

--- a/bin/wayland-launch
+++ b/bin/wayland-launch
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -e
-set -x
 
 for PLUG in %PLUGS%; do
   if ! snapctl is-connected ${PLUG}
   then
-    echo "${PLUG} interface not connected! Please run: /snap/%SNAP%/current/bin/setup.sh"
-    exit 1
+    echo "WARNING: ${PLUG} interface not connected! Please run: /snap/%SNAP%/current/bin/setup.sh"
   fi
 done
 


### PR DESCRIPTION
Where plugs still need connecting prefer a system slot.

Where there's no system "wayland" plug we also check for ubuntu-frame and mir-kiosk.

Erroring is too drastic for interfaces that might not be needed: a WARNING is enough.

Finally there's too much spam in the logs.