### PR TITLE
Enable "snap run" of daemons as non-root

### DIFF
--- a/bin/run-daemon
+++ b/bin/run-daemon
@@ -2,7 +2,7 @@
 
 set -x
 
-if [ "$(snapctl get daemon)" = "true" ]
+if [ "$(snapctl get daemon)" = "true" ] || [ "$(id -u)" != "0" ]
 then exec "$@"
 else
   # It is unlikely, but possible for "snapctl stop ..." to fail


### PR DESCRIPTION
run-daemon should continue chain when run as non-root