### PR TITLE
ERROR if inotifywait could not be found

### DIFF
--- a/bin/wayland-launch
+++ b/bin/wayland-launch
@@ -8,6 +8,14 @@ for PLUG in %PLUGS%; do
   fi
 done
 
+if ! command -v inotifywait > /dev/null
+then
+    echo "ERROR: inotifywait could not be found, mir-kiosk-snap-launch expects:"
+    echo " . . :     stage-packages:"
+    echo " . . :        - inotify-tools"
+    exit 1
+fi
+
 wait_for()
 {
   until


### PR DESCRIPTION
A more helpful failure mode if  `inotify-tools` is not staged.

NB Not a "warning with fallback" because if the fallback works nobody will look for or heed a warning.

Fixes: #16